### PR TITLE
Add ability to generate afni-esque dictionary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "bids2table[s3]>=2.1.0",
     "polars>=1.31.0",
+    "templateflow>=24.2.2",
 ]
 
 [project.scripts]

--- a/src/bids2afniqcjson/main.py
+++ b/src/bids2afniqcjson/main.py
@@ -1,9 +1,11 @@
+from functools import partial
 from typing import overload
 
 import bids2table as b2t
 import polars as pl
 import pyarrow as pa
 from bids2table._pathlib import PathT, as_path
+from templateflow import api as tflow
 
 
 @overload
@@ -56,5 +58,66 @@ def load_dataset(
     return pl.from_arrow(table)
 
 
+def _query_dataset(table: pl.DataFrame, query: str) -> pl.DataFrame:
+    """Query for a specific thing via SQL queries."""
+    return table.sql(f"SELECT * FROM self WHERE {query}")
+
+
+def _get_fpath(table: pl.DataFrame) -> str:
+    """Grab absolute file path of file."""
+    return str(as_path("/".join(table.select(["root", "path"]).row(0))).resolve())
+
+
+def create_afni_json(unique_table: pl.DataFrame, out_dir: PathT) -> dict[str, str]:
+    """Query a unique table (e.g. sub, ses, run, etc.) for specific files."""
+
+    def _create_ss_review_dset(repetitions: int, out_dir: PathT) -> str:
+        """Create out.ss_review.FT.txt with the number of TRs per run as needed."""
+        out_fpath = (out_dir / "out.ss_review.FT.txt").resolve()
+        out_fpath.write_text(f"num_TRs_per_run: {repetitions}")
+        return str(out_fpath)
+
+    subject_query = partial(_query_dataset, unique_table)
+    subject = unique_table.select("sub")[0].item()
+
+    # Create base JSON file
+    # NOTE_1: Need to rethink querying to be more flexible (e.g. space, run, etc.)
+    # NOTE_2: Is there another way to grab the templateflow templates (s3?)
+    afni_json = {
+        "copy_anat": _get_fpath(
+            table=subject_query(
+                query="datatype = 'anat' AND space = 'MNI152NLin2009cAsym' AND desc = 'preproc' AND suffix = 'T1w' AND ext = '.nii.gz'"
+            )
+        ),
+        "final_anat": _get_fpath(
+            table=subject_query(
+                query="datatype = 'anat' AND space = 'MNI152NLin2009cAsym' AND desc = 'preproc' AND suffix = 'T1w' AND ext = '.nii.gz'"
+            )
+        ),
+        "template": str(
+            tflow.get(
+                template="MNI152NLin2009cAsym",
+                desc=None,
+                resolution=2,
+                suffix="T1w",
+                extension=".nii.gz",
+            )
+        ),
+        "ss_review_dset": _create_ss_review_dset(repetitions=1, out_dir=out_dir),
+        "subj": f"sub-{subject}" if not subject.startswith("sub") else {subject},
+        "mask_dset": _get_fpath(
+            table=subject_query(
+                query="datatype = 'func' AND task = 'balloonanalogrisktask' AND desc = 'brain' AND suffix = 'mask' AND ext = '.nii.gz'"
+            )
+        ),
+        "vr_base_dset": _get_fpath(
+            table=subject_query(
+                query="datatype = 'func' AND task = 'balloonanalogrisktask' AND suffix = 'boldref' AND ext = '.nii.gz'"
+            )
+        ),
+    }
+
+    return afni_json
+
+
 if __name__ == "__main__":
-    ...


### PR DESCRIPTION
Initial attempt at generating an AFNI-esque dictionary - some things need to be tinkered with a little bit still, but the general idea is there:

1. Querying should be flexible (for runs, space, etc.)
2. Switch to pulling templateflow from s3 bucket directly (via `bids2table` + `boto3`?)
3. Maybe an argparse to pass input directory (also output or can this be inferred?)